### PR TITLE
feat: multi-CUDA matrix + backend selection + daily nightly build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,11 @@
 name: Build
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 2 * * *'   # daily at 2 AM UTC — nightly build
+  workflow_dispatch:       # allow manual trigger from GitHub UI
 
 jobs:
   build:
@@ -13,7 +18,16 @@ jobs:
           - name: deepmd-kit
             platform: linux-64
           - name: deepmd-kit
+            cuda: '12.6'
+            platform: linux-64
+          - name: deepmd-kit
+            cuda: '12.8'
+            platform: linux-64
+          - name: deepmd-kit
             cuda: '12.9'
+            platform: linux-64
+          - name: deepmd-kit
+            cuda: '13.1'
             platform: linux-64
     env:
       version: "3.2.0b0"

--- a/deepmd-kit/construct.yaml
+++ b/deepmd-kit/construct.yaml
@@ -1,5 +1,10 @@
 {% set version = os.environ.get("VERSION") %}
 {% set cuda_version = os.environ.get("CUDA_VERSION") %}
+{% set backend = os.environ.get("DP_BACKEND", "all") %}
+{% set torch_version = os.environ.get("TORCH_VERSION", "") %}
+{% set with_tf = backend in ("all","tensorflow") %}
+{% set with_pt = backend in ("all","pytorch") and torch_version %}
+{% set with_jax = backend in ("all","jax") %}
 {% if cuda_version == '' %}
 {% set variant = "cpu" %}
 {% set variant_version = "cpu" %}
@@ -29,12 +34,18 @@ specs:
 - openmpi
 {% endif %}
 - libblas * *mkl
+{% if with_tf %}
 - tensorflow >=2.19
-# jax
+{% endif %}
+{% if with_pt %}
+- pytorch {{ torch_version }}
+{% endif %}
+{% if with_jax %}
 - jax
 - jaxlib * {{ variant }}*
 - flax >=0.10.0
 - orbax-checkpoint
+{% endif %}
 
 ignore_duplicate_files: True
 


### PR DESCRIPTION
Add three features to the installer CI:

1. **Multi-CUDA support**: build matrix now includes CUDA 12.6, 12.8, 12.9, and 13.1
2. **Backend selection**: new env vars `DP_BACKEND` (all/tensorflow/pytorch/jax) and `TORCH_VERSION`
   allow users to select which ML backends to bundle
3. **Nightly schedule**: `cron: 0 2 * * *` triggers daily builds, plus `workflow_dispatch` for manual runs

Tested: CPU + GPU (4×V100 cuda129) with PyTorch backend, dpa4 model training + LAMMPS inference
verified offline on Bohrium.

Ref: https://github.com/deepmd-kit-recipes/installer
